### PR TITLE
Adjust test matrix to use Wagtail 5.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
 minversion = 3.14.6
 envlist =
-    py{38,39,310}-dj{32,41}-wagtail{41,42,50,51}
-    py311-dj41-wagtail{41,42,50,51}
-    py311-dj42-wagtail{50,51}
+    py{38,39,310}-dj{32,41}-wagtail{41,51,52}
+    py311-dj{42}-wagtail{51,52}
     coverage-report
 
 [gh-actions]
@@ -21,8 +20,8 @@ deps =
     dj41: django>=4.1,<4.2
     dj42: django>=4.2,<4.3
     wagtail41: wagtail>=4.1,<5.0
-    wagtail50: wagtail>=5.0,<5.1
     wagtail51: wagtail>=5.1,<5.2
+    wagtail52: wagtail>=5.2,<5.3
 
 [testenv:coverage-report]
 basepython = python3.11


### PR DESCRIPTION
# Wagtail 5.2 Upgrade

- Drop wagtail 5.0 from the test matrix
- Add Wagtail 5.2 and Django 4.2 to the test matrix