### PR TITLE
Wagtail 6.0

### DIFF
--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -9,12 +9,12 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [unreleased] - YYYY-MM-DD
 
+- Adjust test matrix to use Wagtail 6.0 [@katdom13](https://github.com/katdom13)
+- Drop Wagtail < 5.2 from the test matrix [@katdom13](https://github.com/katdom13)
+- Add Python 3.12 to test matrix [@katdom13](https://github.com/katdom13)
+- Update minimum Wagtail version to 5.2 in setup.py [@katdom13](https://github.com/katdom13)
+
 ## [v2.0.0] - 2023-12-19
 
 - Adjust test matrix to use Wagtail 5.2 [@nickmoreton](https://github.com/nickmoreton)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Install using pip:
 pip install wagtail-accessibility
 ```
 
-Then add `wagtailaccessibility` to your `INSTALLED_APPS`. It works with Wagtail 4.1 and upwards.
+Then add `wagtailaccessibility` to your `INSTALLED_APPS`. It works with Wagtail 5.2 and upwards.
 
 ## Using
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-wagtail>=4.1
+wagtail>=5.2
 pytest==6.2.5
 pytest-cov==3.0.0
 pytest-django==4.5.0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", encoding="utf-8") as readme_file:
 
 
 install_requires = [
-    'wagtail>=4.1',
+    'wagtail>=5.2',
 ]
 
 tests_require = [
@@ -58,11 +58,12 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         "Framework :: Django",
+        "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
         "Framework :: Wagtail",
-        "Framework :: Wagtail :: 4",
         "Framework :: Wagtail :: 5",
+        "Framework :: Wagtail :: 6",
         'License :: OSI Approved :: BSD License',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Site Management',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -5,12 +5,9 @@ from tests.testapp.models import SimplePage
 
 
 validity = {
-    'is_valid': True
+    'is_valid': True,
+    'is_available': True,
 }
-
-if settings.WAGTAIL_VERSION >= (4, 0):
-    validity['is_available'] = True
-
 
 def test_preview(admin_client):
     simple_page = SimplePage.objects.first()

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ minversion = 3.14.6
 envlist =
     py{38,39,310}-dj32-wagtail52
     py{38,39,310,311}-dj42-wagtail{52,60}
-    py{311,312}-dj50-wagtail{52,60}
+    py{310,311,312}-dj50-wagtail{52,60}
     coverage-report
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 minversion = 3.14.6
 envlist =
-    py{38,39,310}-dj{32,41}-wagtail{41,51,52}
-    py311-dj{42}-wagtail{51,52}
+    py{38,39,310}-dj32-wagtail52
+    py{38,39,310,311}-dj42-wagtail{52,60}
+    py{311,312}-dj50-wagtail{52,60}
     coverage-report
 
 [gh-actions]
@@ -11,20 +12,20 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}
 extras = test
 deps =
     dj32: django>=3.2,<3.3
-    dj41: django>=4.1,<4.2
     dj42: django>=4.2,<4.3
-    wagtail41: wagtail>=4.1,<5.0
-    wagtail51: wagtail>=5.1,<5.2
+    dj50: django>=5.0,<5.1
     wagtail52: wagtail>=5.2,<5.3
+    wagtail60: wagtail>=6.0,<6.1
 
 [testenv:coverage-report]
-basepython = python3.11
+basepython = python3.12
 deps = coverage
 pip_pre = true
 skip_install = true


### PR DESCRIPTION
[Support Ticket](https://torchbox.monday.com/boards/1124794299/pulses/1396934053)

## [Wagtail 6.0 release notes](https://docs.wagtail.org/en/stable/releases/6.0.html)

### Summary of changes

- Adjust test matrix to use Wagtail 6.0
- Drop Wagtail < 5.2 from the test matrix
- Add Python 3.12 to test matrix
- Update minimum Wagtail version to 5.2 in setup.py