### PR TITLE
Wagtail 6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [unreleased] - YYYY-MM-DD
 
-- Adjust test matrix to use Wagtail 6.0 [@katdom13](https://github.com/katdom13)
+- Adjust test matrix to use Wagtail 6 [@katdom13](https://github.com/katdom13)
 - Drop Wagtail < 5.2 from the test matrix [@katdom13](https://github.com/katdom13)
 - Add Python 3.12 to test matrix [@katdom13](https://github.com/katdom13)
 - Update minimum Wagtail version to 5.2 in setup.py [@katdom13](https://github.com/katdom13)

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 minversion = 3.14.6
 envlist =
     py{38,39,310}-dj32-wagtail52
-    py{38,39,310,311}-dj42-wagtail{52,60}
-    py{310,311,312}-dj50-wagtail{52,60}
+    py{38,39,310,311}-dj42-wagtail{52,60,61}
+    py{310,311,312}-dj50-wagtail{52,60,61}
     coverage-report
 
 [gh-actions]
@@ -23,6 +23,7 @@ deps =
     dj50: django>=5.0,<5.1
     wagtail52: wagtail>=5.2,<5.3
     wagtail60: wagtail>=6.0,<6.1
+    wagtail61: wagtail>=6.1,<6.2
 
 [testenv:coverage-report]
 basepython = python3.12


### PR DESCRIPTION
# Notes

- No significant changes related to Wagtail 6.1

# Wagtail 6.1 upgrade check list

## Code reviewing a consideration.
Use the tick box to indicate a consideration has been code reviewed as OK

### What’s new
  - [x] [Universal listings continued](https://docs.wagtail.org/en/latest/releases/6.1.html#universal-listings-continued)
  - [x] [Information-dense admin interface](https://docs.wagtail.org/en/latest/releases/6.1.html#information-dense-admin-interface)
  - [x] [Custom per-page-type listings](https://docs.wagtail.org/en/latest/releases/6.1.html#custom-per-page-type-listings)
  - [x] [Keyboard shortcuts overview](https://docs.wagtail.org/en/latest/releases/6.1.html#keyboard-shortcuts-overview)
  - [x] [Better guidance for password-protected content](https://docs.wagtail.org/en/latest/releases/6.1.html#better-guidance-for-password-protected-content)
  - [x] [Favicon images generation](https://docs.wagtail.org/en/latest/releases/6.1.html#favicon-images-generation)
  - [x] [Cve-2024-32882: permission check bypass when editing a model with per-field restrictions through wagtail.contrib.settings or modelviewset](https://docs.wagtail.org/en/latest/releases/6.1.html#cve-2024-32882-permission-check-bypass-when-editing-a-model-with-per-field-restrictions-through-wagtail-contrib-settings-or-modelviewset)
  - [x] [Other features](https://docs.wagtail.org/en/latest/releases/6.1.html#other-features)
  - [x] [Bug fixes](https://docs.wagtail.org/en/latest/releases/6.1.html#bug-fixes)
  - [x] [Documentation](https://docs.wagtail.org/en/latest/releases/6.1.html#documentation)
  - [x] [Maintenance](https://docs.wagtail.org/en/latest/releases/6.1.html#maintenance)
### Changes affecting wagtail customizations
  - [x] [Changes to submissionslistview class](https://docs.wagtail.org/en/latest/releases/6.1.html#changes-to-submissionslistview-class)
  - [x] [Register_user_listing_buttons hook signature changed](https://docs.wagtail.org/en/latest/releases/6.1.html#register-user-listing-buttons-hook-signature-changed)
  - [x] [Password_required_template has changed to wagtail_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#password-required-template-has-changed-to-wagtail-password-required-template)
  - [x] [Document_password_required_template has changed to wagtaildocs_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#document-password-required-template-has-changed-to-wagtaildocs-password-required-template)
### Changes to undocumented internals
  - [x] [Deprecation of user_listing_buttons template tag](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-user-listing-buttons-template-tag)
  - [x] [Deprecation of wagtailusers_groups:users url pattern](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-wagtailusers-groups-users-url-pattern)
  - [x] [Deprecation of window.chooserurls within draftail choosers](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-chooserurls-within-draftail-choosers)
  - [x] [Deprecation of window.initblockwidget to initialize a streamfield block](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-initblockwidget-to-initialize-a-streamfield-block)
  - [x] [Old](https://docs.wagtail.org/en/latest/releases/6.1.html#id1)
  - [x] [New](https://docs.wagtail.org/en/latest/releases/6.1.html#id2)
  - [x] [Removal of jquery from base client-side widget and boundwidget classes](https://docs.wagtail.org/en/latest/releases/6.1.html#removal-of-jquery-from-base-client-side-widget-and-boundwidget-classes)
  - [x] [Window.urlify deprecated](https://docs.wagtail.org/en/latest/releases/6.1.html#window-urlify-deprecated)
  - [x] [Window.xregexp polyfill removed](https://docs.wagtail.org/en/latest/releases/6.1.html#window-xregexp-polyfill-removed)